### PR TITLE
Add preload template

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Follow the interactive wizard to configure:
 After completion, your project folder includes:
 
 * `src/` - Electron main process and frontend sources
+* `src/preload.ts` - exposes IPC-safe APIs when the preload feature is enabled
 * `public/` - Static assets including `index.html`
 * `package.json` - with all scripts and dependencies
 * `.prettierrc` and `.eslintrc` - code style configs

--- a/src/generator.js
+++ b/src/generator.js
@@ -68,6 +68,16 @@ export async function scaffoldProject(answers) {
     throw new Error(`Failed copying base templates: ${e.message}`);
   }
 
+  // Include preload script only if feature selected
+  const preloadFile = path.join(outDir, "src", "preload.ts");
+  if (!answers.features.includes("preload")) {
+    try {
+      await fs.rm(preloadFile, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+
   // Copy feature templates conditionally
   for (const feature of answers.features) {
     if (feature === "prettier" || feature === "darkmode" || feature === "git") {

--- a/templates/base/src/preload.ts
+++ b/templates/base/src/preload.ts
@@ -1,0 +1,13 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+// Expose a very small API for the renderer process.
+export const api = {
+  send(channel: string, data?: any) {
+    ipcRenderer.send(channel, data);
+  },
+  on(channel: string, listener: (...args: unknown[]) => void) {
+    ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+  }
+};
+
+contextBridge.exposeInMainWorld('api', api);


### PR DESCRIPTION
## Summary
- add preload script template exposing a safe IPC API
- only copy preload.ts when the preload feature is enabled
- document preload.ts in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686304031a40832fb28424db482610df