### PR TITLE
Add SQLite init script template

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -48,6 +48,10 @@ export async function scaffoldProject(answers) {
       pkg.scripts[key] = fullScriptMap[key];
     }
   }
+
+  if (answers.features.includes("sqlite")) {
+    pkg.scripts["dbinit"] = fullScriptMap.dbinit;
+  }
   pkg.dependencies = dependencies;
 
   try {

--- a/templates/with-sqlite/scripts/init-db.js
+++ b/templates/with-sqlite/scripts/init-db.js
@@ -1,0 +1,17 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+const dbPath = path.join(process.cwd(), 'app.db');
+const db = new Database(dbPath);
+
+db.prepare(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+  )
+`).run();
+
+console.log('Database initialized at', dbPath);
+
+db.close();
+


### PR DESCRIPTION
## Summary
- add `scripts/init-db.js` template for sqlite setups
- auto inject `dbinit` script into generated package.json when sqlite feature selected

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_686304077ce8832fa0f2cfc39dc290db