### PR TITLE
Rename to create-electron-app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,12 @@
 
 
-## 🛠 `makeapp` CLI Tool — Architecture & Flow (Electron + React + Vite Generator)
+## 🛠 `create-electron-app` CLI Tool — Architecture & Flow (Electron + React + Vite Generator)
 
 ### 🔰 CLI OVERVIEW
 
-* CLI Name: `makeapp` (global binary installed via `bin/index.js`)
+* CLI Name: `create-electron-app` (global binary installed via `bin/index.js`)
 * Tech: Node.js (ESM), `enquirer` for prompts, modular scaffold logic
-* Run anywhere from terminal: `makeapp`
+* Run anywhere from terminal: `create-electron-app`
 * Generates fully working Electron app (Vite+React+TS) into CWD
 * Output folder: `${cwd}/${appName}`
 
@@ -173,8 +173,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
 
 If you're handing this to Claude or another dev:
 
-1. Ensure `makeapp` CLI is global (`npm link` or installed via symlink)
-2. Run `makeapp` and test every selected feature path.
+1. Ensure `create-electron-app` CLI is global (`npm link` or installed via symlink)
+2. Run `create-electron-app` and test every selected feature path.
 3. `npm run dev` for live mode
 4. `npm run build` → generates `dist/index.js`
 5. `npm run start` for production mode

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# create-my-electron-app
+# create-electron-app
 
 ## Overview
 
-`create-my-electron-app` is a secure, modular CLI scaffolding tool designed to bootstrap modern Electron applications with React and Vite. It streamlines project setup by combining best practices for frontend, backend, and native integration, all configurable through an intuitive interactive wizard.
+`create-electron-app` is a secure, modular CLI scaffolding tool designed to bootstrap modern Electron applications with React and Vite. It streamlines project setup by combining best practices for frontend, backend, and native integration, all configurable through an intuitive interactive wizard.
 
 ---
 
@@ -30,12 +30,12 @@ Clone and install dependencies:
 
 ```bash
 git clone <your-repo-url>
-cd create-my-electron-app
+cd create-electron-app
 npm install
 npm link
 ```
 
-This makes the CLI globally available as `create-my-electron-app` (or your custom command).
+This makes the CLI globally available as `create-electron-app` (or your custom command).
 
 ---
 
@@ -44,7 +44,7 @@ This makes the CLI globally available as `create-my-electron-app` (or your custo
 Run anywhere in your terminal:
 
 ```bash
-create-my-electron-app
+create-electron-app
 ```
 
 Follow the interactive wizard to configure:

--- a/bin/index.js
+++ b/bin/index.js
@@ -7,7 +7,7 @@ import { info, error as logError } from "../src/utils/logger.js";
 
 async function main() {
   try {
-    info("🛠️  create-my-electron-app CLI\n-----------------------------");
+    info("🛠️  create-electron-app CLI\n-----------------------------");
 
     const answers = await createAppWizard();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "create-my-electron-app",
+  "name": "create-electron-app",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "create-my-electron-app",
+      "name": "create-electron-app",
       "version": "1.0.0",
       "dependencies": {
         "boxen": "^8.0.1",
@@ -14,7 +14,7 @@
         "prompts": "^2.4.2"
       },
       "bin": {
-        "makeapp": "bin/index.js"
+        "create-electron-app": "bin/index.js"
       }
     },
     "node_modules/ansi-align": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "create-my-electron-app",
+  "name": "create-electron-app",
   "version": "1.0.0",
   "type": "module",
   "main": "bin/index.js",
   "bin": {
-    "makeapp": "./bin/index.js"
+    "create-electron-app": "./bin/index.js"
   },
   "scripts": {
     "start": "node bin/index.js"


### PR DESCRIPTION
## Summary
- rename project and CLI from `create-my-electron-app`/`makeapp` to `create-electron-app`
- update README and AGENTS documentation for new command name
- adjust package name and binary mapping

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863069baf94832fbb419db1485604c5