### PR TITLE
Clarify SSO auth template

### DIFF
--- a/templates/with-sso/auth.js
+++ b/templates/with-sso/auth.js
@@ -1,13 +1,22 @@
 import { ipcMain } from 'electron';
 
-ipcMain.handle('auth-login', async (event, credentials) => {
-  if (!credentials || !credentials.username || !credentials.password) {
-    return { success: false, error: 'Missing credentials' };
-  }
+/**
+ * Placeholder authentication handler used by the SSO template.
+ *
+ * This file intentionally contains **no real authentication logic** so that
+ * applications do not ship with insecure default credentials.
+ * Replace this entire file with your organisation's SSO/AD integration before
+ * distributing your app.
+ */
+ipcMain.handle('auth-login', async () => {
+  console.warn(
+    '[SSO] Placeholder auth handler invoked. Replace templates/with-sso/auth.js with real integration.'
+  );
 
-  // TODO: Replace with real AD/SSO integration
-  if (credentials.username === 'admin' && credentials.password === 'password') {
-    return { success: true, user: { username: credentials.username, roles: ['admin'] } };
-  }
-  return { success: false, error: 'Invalid username or password' };
+  // Always fail to enforce replacing this placeholder implementation.
+  return {
+    success: false,
+    error:
+      'Authentication placeholder - replace templates/with-sso/auth.js with real SSO integration.'
+  };
 });


### PR DESCRIPTION
## Summary
- mark the SSO auth file as a placeholder and remove hardcoded credentials

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863082fc1fc832f9e722b174b8e19f9