### PR TITLE
Add NODE_ENV dev tool check

### DIFF
--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -13,7 +13,7 @@ export const scriptOptions = [
 ];
 
 export const fullScriptMap = {
-  dev: "vite --config vite.config.js && electron .",
+  dev: "NODE_ENV=development vite --config vite.config.js && NODE_ENV=development electron .",
   build: "tsc && vite build",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",

--- a/templates/base/src/main.ts
+++ b/templates/base/src/main.ts
@@ -13,7 +13,10 @@ function createWindow() {
   });
 
   win.loadURL("http://localhost:3000");
-  win.webContents.openDevTools();
+
+  if (process.env.NODE_ENV === "development") {
+    win.webContents.openDevTools();
+  }
 }
 
 app.whenReady().then(() => {


### PR DESCRIPTION
## Summary
- only open devtools in development
- set NODE_ENV during `npm run dev`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863082e02c0832f9c198ce1cd34727a