### PR TITLE
Improve preload channel security

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,24 @@ Follow the interactive wizard to configure your project. The prompts now include
 After completion, your project folder includes:
 
 * `src/` - Electron main process and frontend sources
-* `src/preload.ts` - exposes IPC-safe APIs when the preload feature is enabled
+* `src/preload.ts` - exposes IPC-safe APIs using an allowlist of channels
 * `public/` - Static assets including `index.html`
 * `package.json` - with all scripts and dependencies
 * `.prettierrc` and `.eslintrc` - code style configs
 * Modular feature files (e.g., `db.js` for SQLite)
 * Config files, README, and roadmap documents
+
+## Adding IPC Channels
+
+`src/preload.ts` contains two arrays, `allowedSendChannels` and `allowedReceiveChannels`, which control which IPC messages the renderer may use. To expose a new channel, add its name to one of these arrays:
+
+```ts
+// src/preload.ts
+const allowedSendChannels = ['toMain', 'settings:update'];
+const allowedReceiveChannels = ['fromMain', 'settings:changed'];
+```
+
+This pattern keeps the IPC surface minimal and secure.
 
 ---
 

--- a/templates/base/src/preload.ts
+++ b/templates/base/src/preload.ts
@@ -1,13 +1,22 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
-// Expose a very small API for the renderer process.
+// Allowed channels must be explicitly listed. Add new channels here
+// to make them accessible from the renderer process.
+const allowedSendChannels = ['toMain'];
+const allowedReceiveChannels = ['fromMain'];
+
+// Expose a very small API for the renderer process using the allowlists above.
 export const api = {
-  send(channel: string, data?: any) {
-    ipcRenderer.send(channel, data);
+  send(channel: string, data?: unknown) {
+    if (allowedSendChannels.includes(channel)) {
+      ipcRenderer.send(channel, data);
+    }
   },
   on(channel: string, listener: (...args: unknown[]) => void) {
-    ipcRenderer.on(channel, (_event, ...args) => listener(...args));
-  }
+    if (allowedReceiveChannels.includes(channel)) {
+      ipcRenderer.on(channel, (_event, ...args) => listener(...args));
+    }
+  },
 };
 
 contextBridge.exposeInMainWorld('api', api);


### PR DESCRIPTION
## Summary
- restrict IPC exposure in preload template
- document IPC allowlist and how to add channels

## Testing
- `npm test` *(fails: Missing script)*
- `npm start -- --help` *(CLI launches and aborts)*

------
https://chatgpt.com/codex/tasks/task_e_6863082e8990832f84deca34dd980178