### PR TITLE
Remove unused pipeline helper

### DIFF
--- a/src/utils/fileOps.js
+++ b/src/utils/fileOps.js
@@ -2,10 +2,6 @@
 
 import fs from "fs/promises";
 import path from "path";
-import { promisify } from "util";
-import { pipeline } from "stream";
-
-const streamPipeline = promisify(pipeline);
 
 export async function ensureDir(dirPath) {
   try {


### PR DESCRIPTION
## Summary
- delete unused `streamPipeline` definition

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_686309705410832f8afee7edcaf23c17