### PR TITLE
Fix prettier feature templates

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -96,11 +96,14 @@ export async function scaffoldProject(answers) {
 
   // Copy feature templates conditionally
   for (const feature of answers.features) {
-    if (feature === "prettier" || feature === "git") {
-      // skip features that don't have templates or are handled separately
+    if (feature === "git") {
+      // skip features handled separately
       continue;
     }
-    const featureTemplateDir = path.resolve(__dirname, `../templates/with-${feature}`);
+    const featureTemplateDir = path.resolve(
+      __dirname,
+      `../templates/with-${feature}`
+    );
     try {
       await fs.access(featureTemplateDir);
       await copyDirRecursive(featureTemplateDir, outDir);


### PR DESCRIPTION
## Summary
- copy templates for `prettier`
- allow `.prettierrc` and `.prettierignore` to be included when the prettier feature is enabled

## Testing
- `node` test to scaffold project with prettier feature

------
https://chatgpt.com/codex/tasks/task_e_68630968eac4832f9e74343af34275a7