### PR TITLE
Add script-based dev dependencies

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -83,6 +83,14 @@ export async function scaffoldProject(answers) {
     }
   }
 
+  // Script-specific dev dependencies
+  if (answers.scripts.includes("dist")) {
+    pkg.devDependencies["electron-builder"] = "^26.0.0";
+  }
+  if (answers.scripts.includes("clean") || answers.scripts.includes("reset")) {
+    pkg.devDependencies["rimraf"] = "^6.0.1";
+  }
+
   try {
     await fs.writeFile(
       path.join(outDir, "package.json"),
@@ -157,6 +165,17 @@ export async function scaffoldProject(answers) {
       await copyDirRecursive(featureTemplateDir, outDir);
     } catch {
       // No template for feature; silently continue
+    }
+  }
+
+  // Include electron-builder config if dist script selected
+  if (answers.scripts.includes("dist")) {
+    const builderTemplate = path.resolve(__dirname, "../templates/with-dist");
+    try {
+      await fs.access(builderTemplate);
+      await copyDirRecursive(builderTemplate, outDir);
+    } catch {
+      // ignore if template missing
     }
   }
 

--- a/templates/with-dist/electron-builder.yml
+++ b/templates/with-dist/electron-builder.yml
@@ -1,0 +1,6 @@
+appId: com.example.{{APP_NAME}}
+productName: {{APP_NAME}}
+files:
+  - dist/**
+  - node_modules/**
+  - package.json


### PR DESCRIPTION
## Summary
- install `electron-builder` when the `dist` script is selected
- install `rimraf` when `clean` or `reset` scripts are chosen
- copy new `electron-builder.yml` template for packaging

## Testing
- `node -e "import('./src/generator.js').then(()=>console.log('ok')).catch(err=>{console.error(err); process.exit(1);})"`

------
https://chatgpt.com/codex/tasks/task_e_68630c86cfd0832f8472c45e9ac7a988