### PR TITLE
Add gradient banner to CLI

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,10 +1,23 @@
 #!/usr/bin/env node
 // File: bin/index.js
 
+import gradient from "gradient-string";
 import { createAppWizard } from "../src/wizard.js";
 import { scaffoldProject } from "../src/generator.js";
 import { showSummaryReport } from "../src/report.js";
 import { info, error as logError } from "../src/utils/logger.js";
+
+const title = `
+                             __                          .__                 __                                                       
+  ___________   ____ _____ _/  |_  ____             ____ |  |   ____   _____/  |________  ____   ____           _____  ______ ______  
+_/ ___\\_  __ \\_/ __ \\__  \\   __\\/ __ \\   ______ _/ __ \\|  | _/ __ \\_/ ___\\   __\\_  __ \\/  _ \\ /    \\   ______ \\__  \\ \____ \\____ \\ 
+\\  \___|  | \\/\\  ___/ / __ \\|  | \\  ___/  /_____/ \\  ___/|  |_\\  ___/\\  \___|  |  |  | \\(  <_> )   |  \\ /_____/  / __ \\|  |_> >  |_> >
+ \___  >__|    \\___  >____  /__|  \\___  >          \\___  >____/\\___  >\\___  >__|  |__|   \\____/|___|  /         (____  /   __/|   __/ 
+     \\/            \\/     \\/          \\/               \\/          \\/     \\/                        \\/               \\/|__|   |__|    
+`;
+
+console.clear();
+console.log(gradient.rainbow.multiline(title));
 
 async function main() {
   try {
@@ -24,3 +37,4 @@ async function main() {
 }
 
 main();
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,18 @@
         "boxen": "^8.0.1",
         "chalk": "^5.4.1",
         "execa": "^7.1.1",
+        "gradient-string": "^3.0.0",
         "prompts": "^2.4.2"
       },
       "bin": {
         "create-electron-app": "bin/index.js"
       }
+    },
+    "node_modules/@types/tinycolor2": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.6.tgz",
+      "integrity": "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw==",
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -214,6 +221,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gradient-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/gradient-string/-/gradient-string-3.0.0.tgz",
+      "integrity": "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "tinygradient": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/human-signals": {
@@ -418,6 +438,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
+    "node_modules/tinygradient": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.5.tgz",
+      "integrity": "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/tinycolor2": "^1.4.0",
+        "tinycolor2": "^1.0.0"
       }
     },
     "node_modules/type-fest": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "boxen": "^8.0.1",
     "chalk": "^5.4.1",
     "execa": "^7.1.1",
+    "gradient-string": "^3.0.0",
     "prompts": "^2.4.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `gradient-string` dependency
- print ASCII banner with rainbow gradient at CLI startup
- keep index.js executable

## Testing
- `node bin/index.js` *(aborts at first prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68630d55224c832fb8ade0a96c27111b