### PR TITLE
Fix ESLint version in generator

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -53,7 +53,7 @@ export async function scaffoldProject(answers) {
     prettier: { devDependencies: { prettier: "^3.6.2" } },
     eslint: {
       devDependencies: {
-        eslint: "^9.30.0",
+        eslint: "^8.56.0",
         "@typescript-eslint/parser": "^7.0.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
       },


### PR DESCRIPTION
## Summary
- pin eslint at v8.56.0 in generator

## Testing
- `npm install`
- `node --input-type=module - <<'EOF' ...` (scaffold project with all features)


------
https://chatgpt.com/codex/tasks/task_e_68630e9f2a74832f8cebd714ae0477a9