### PR TITLE
Support YAML in token rendering

### DIFF
--- a/src/utils/render.js
+++ b/src/utils/render.js
@@ -16,7 +16,7 @@ export async function renderTemplateFiles(dir, tokens) {
   const files = await listAllFiles(dir);
   for (const file of files) {
     const ext = path.extname(file);
-    if ([".js", ".ts", ".json", ".html", ".md"].includes(ext)) {
+    if ([".js", ".ts", ".json", ".html", ".md", ".yml", ".yaml"].includes(ext)) {
       let content = await fs.readFile(file, "utf-8");
       for (const [key, val] of Object.entries(tokens)) {
         const pattern = new RegExp(`{{\s*${key}\s*}}`, "g");


### PR DESCRIPTION
## Summary
- allow `.yml` and `.yaml` files to have tokens replaced

## Testing
- `node -e "import('./src/utils/render.js').then(()=>console.log('ok')).catch(console.error)"`


------
https://chatgpt.com/codex/tasks/task_e_6863112286a8832fa2fc87be2c6648b6