### PR TITLE
Fix core feature options unselectable

### DIFF
--- a/src/config/featureSets.js
+++ b/src/config/featureSets.js
@@ -1,7 +1,25 @@
 export const featureChoices = [
-  { title: "React (via Vite)", value: "react", selected: true, description: "Modern React setup" },
-  { title: "TypeScript", value: "typescript", selected: true, description: "Type safety" },
-  { title: "Electron", value: "electron", selected: true, description: "Desktop shell" },
+  {
+    title: "React (via Vite)",
+    value: "react",
+    selected: true,
+    disabled: true,
+    description: "Modern React setup",
+  },
+  {
+    title: "TypeScript",
+    value: "typescript",
+    selected: true,
+    disabled: true,
+    description: "Type safety",
+  },
+  {
+    title: "Electron",
+    value: "electron",
+    selected: true,
+    disabled: true,
+    description: "Desktop shell",
+  },
   { title: "Preload (secure IPC)", value: "preload", selected: true, description: "Expose safe APIs" },
   { title: "ESLint", value: "eslint", selected: true, description: "Linting rules" },
   { title: "Prettier", value: "prettier", selected: true, description: "Code formatter" },


### PR DESCRIPTION
## Summary
- ensure React, TypeScript, and Electron options are locked in the wizard

## Testing
- `node -e "console.log('sanity')"`


------
https://chatgpt.com/codex/tasks/task_e_68631122fa2c832fa08bf4d4fb9eba07