### PR TITLE
Add Node engines requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 ## Installation
 
+Ensure you have **Node.js 18 or higher** installed.
+
 Clone and install dependencies:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "scripts": {
     "start": "node bin/index.js"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "boxen": "^8.0.1",
     "chalk": "^5.4.1",


### PR DESCRIPTION
## Summary
- ensure Node.js 18+ is required via `engines` in `package.json`
- document the Node.js version requirement in installation instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863127c8d80832fa87f755162893063