### PR TITLE
Add cross-env to dev script workflow

### DIFF
--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -13,7 +13,7 @@ export const scriptOptions = [
 ];
 
 export const fullScriptMap = {
-  dev: "NODE_ENV=development vite --config vite.config.js && NODE_ENV=development electron .",
+  dev: "cross-env NODE_ENV=development vite --config vite.config.js && cross-env NODE_ENV=development electron .",
   build: "tsc && vite build",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",

--- a/src/generator.js
+++ b/src/generator.js
@@ -102,6 +102,9 @@ export async function scaffoldProject(answers) {
   if (answers.scripts.includes("clean") || answers.scripts.includes("reset")) {
     pkg.devDependencies["rimraf"] = "^6.0.1";
   }
+  if (answers.scripts.includes("dev")) {
+    pkg.devDependencies["cross-env"] = "^7.0.3";
+  }
 
   try {
     await fs.writeFile(


### PR DESCRIPTION
## Summary
- add cross-env as a dev dependency when the dev script is selected
- prefix vite and electron in the dev script with cross-env

## Testing
- `npm view cross-env version`

------
https://chatgpt.com/codex/tasks/task_e_6863127c2a0c832f8f54a8b5a14833ca