### PR TITLE
Remove redundant Prettier JSON config

### DIFF
--- a/templates/with-prettier/.prettierrc.json
+++ b/templates/with-prettier/.prettierrc.json
@@ -1,7 +1,0 @@
-{
-  "singleQuote": true,
-  "semi": true,
-  "trailingComma": "es5",
-  "printWidth": 80,
-  "tabWidth": 2
-}


### PR DESCRIPTION
## Summary
- drop `.prettierrc.json` so `.prettierrc` is the sole Prettier config in the Prettier template

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68631407bf4c832f9b824e0d9e04f323