### PR TITLE
Add frameless window template

### DIFF
--- a/src/config/featureSets.js
+++ b/src/config/featureSets.js
@@ -27,5 +27,6 @@ export const featureChoices = [
   { title: "SQLite Support", value: "sqlite", description: "Local database" },
   { title: "AD/SSO Login Stub", value: "sso", description: "Placeholder auth" },
   { title: "Dark Mode Support", value: "darkmode", selected: true, description: "OS theme detection" },
+  { title: "Frameless Window", value: "frameless", description: "Custom title bar" },
   
 ];

--- a/src/generator.js
+++ b/src/generator.js
@@ -129,7 +129,8 @@ export async function scaffoldProject(answers) {
   // Include preload script only if feature selected
   const preloadFile = path.join(outDir, "src", "preload.ts");
   const mainFile = path.join(outDir, "src", "main.ts");
-  if (!answers.features.includes("preload")) {
+  const usingPreload = answers.features.includes("preload") || answers.features.includes("frameless");
+  if (!usingPreload) {
     try {
       await fs.rm(preloadFile, { force: true });
     } catch {
@@ -201,6 +202,7 @@ export async function scaffoldProject(answers) {
       WINDOW_TITLE: answers.title,
       AUTHOR: answers.author,
       LICENSE: answers.license,
+      FRAMELESS: answers.features.includes("frameless") ? "true" : "false",
     });
   } catch (e) {
     await cleanupProject();

--- a/templates/with-frameless/src/App.tsx
+++ b/templates/with-frameless/src/App.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import WindowControls from './components/WindowControls';
+
+export default function App() {
+  return (
+    <>
+      <WindowControls />
+      <div style={{ padding: 20 }}>
+        <h1>Hello from Electron + React + Vite!</h1>
+        <p>Your app is running.</p>
+      </div>
+    </>
+  );
+}

--- a/templates/with-frameless/src/components/WindowControls.tsx
+++ b/templates/with-frameless/src/components/WindowControls.tsx
@@ -1,0 +1,30 @@
+export default function WindowControls() {
+  return (
+    <div
+      className="flex justify-end gap-2 p-1 bg-transparent text-white select-none"
+      style={{ WebkitAppRegion: "drag", backgroundColor: "transparent" }}
+    >
+      <button
+        className="px-2"
+        onClick={() => window.windowControls.minimize()}
+        style={{ WebkitAppRegion: "no-drag" }}
+      >
+        –
+      </button>
+      <button
+        className="px-2"
+        onClick={() => window.windowControls.maximize()}
+        style={{ WebkitAppRegion: "no-drag" }}
+      >
+        ⬜
+      </button>
+      <button
+        className="px-2 text-red-500"
+        onClick={() => window.windowControls.close()}
+        style={{ WebkitAppRegion: "no-drag" }}
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/templates/with-frameless/src/main.ts
+++ b/templates/with-frameless/src/main.ts
@@ -1,0 +1,50 @@
+import { app, BrowserWindow, ipcMain } from "electron";
+import path from "path";
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    frame: false,
+    transparent: true,
+    backgroundColor: "#00000000",
+    titleBarStyle: "hiddenInset",
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
+
+  win.loadURL("http://localhost:3000");
+
+  if (process.env.NODE_ENV === "development") {
+    win.webContents.openDevTools();
+  }
+}
+
+ipcMain.on("window:minimize", () => {
+  BrowserWindow.getFocusedWindow()?.minimize();
+});
+ipcMain.on("window:maximize", () => {
+  const win = BrowserWindow.getFocusedWindow();
+  if (win?.isMaximized()) win.unmaximize();
+  else win?.maximize();
+});
+ipcMain.on("window:close", () => {
+  BrowserWindow.getFocusedWindow()?.close();
+});
+
+app.whenReady().then(() => {
+  createWindow();
+
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") {
+    app.quit();
+  }
+});

--- a/templates/with-frameless/src/preload.ts
+++ b/templates/with-frameless/src/preload.ts
@@ -1,0 +1,7 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+contextBridge.exposeInMainWorld("windowControls", {
+  minimize: () => ipcRenderer.send("window:minimize"),
+  maximize: () => ipcRenderer.send("window:maximize"),
+  close: () => ipcRenderer.send("window:close"),
+});


### PR DESCRIPTION
## Summary
- add `frameless` feature option
- keep preload when frameless is selected
- expose FRAMELESS token for template rendering
- implement frameless window templates with IPC and React window controls
- make frameless windows transparent

## Testing
- `node bin/index.js --help`


------
https://chatgpt.com/codex/tasks/task_e_6863fbb8a398832fbf9903a3cc40e619