### PR TITLE
Fix README script and optional Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint
 npm run format  # Run Prettier
 npm run reset   # Remove node_modules and reinstall
-npm run db:init # Initialize the SQLite database
+npm run dbinit # Initialize the SQLite database
 npm run start   # Launch the compiled app
 ```
 

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -5,9 +5,16 @@ import boxen from "boxen";
 import { featureChoices } from "./config/featureSets.js";
 import { scriptOptions } from "./config/scripts.js";
 import { info } from "./utils/logger.js";
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf8"));
+const CLI_NAME = Object.keys(pkg.bin)[0] || "create-electron-app";
 
 function printWelcome() {
-  const msg = `${chalk.bold("create-electron-app")}\nA friendly wizard to scaffold your Electron project.`;
+  const msg = `${chalk.bold(CLI_NAME)}\nA friendly wizard to scaffold your Electron project.`;
   info(boxen(msg, { padding: 1, borderColor: "cyan", margin: 1 }));
   info(chalk.gray("Use arrow keys to navigate, space to select, enter to confirm.\n"));
 }

--- a/templates/base/.prettierrc
+++ b/templates/base/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "semi": true,
-  "singleQuote": true,
-  "printWidth": 80,
-  "trailingComma": "es5",
-  "tabWidth": 2,
-  "useTabs": false
-}


### PR DESCRIPTION
## Summary
- read CLI name from package.json when showing wizard welcome text
- remove `.prettierrc` from base template so it only appears with the Prettier feature
- correct the README SQLite script name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68640407a854832f899f75426ba82ec6