### PR TITLE
Implement OAuth2-based SSO

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Each feature corresponds to `templates/with-<feature>/`:
 * `eslint`: `.eslintrc.js`
 * `prettier`: `.prettierrc`
 * `sqlite`: `sqlite3`, `scripts/init-db.js`
-* `sso`: creates stub file for AD/SSO
+* `sso`: creates login handler for AD/SSO
 * `darkmode`: adds `darkmode.js`
 
 ---

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **ESLint & Prettier** – code quality and formatting
 - **Git initialization** – with an initial commit
 - **SQLite** – optional local database integration
-- **SSO stub** – placeholder for enterprise authentication
+- **SSO login** – enterprise authentication via OAuth2
 - **Dark mode** – aligns with the native OS theme
 - **Packaging** – electron-builder configuration
 - **Predefined npm scripts** – dev, build, lint, format, and more

--- a/src/config/featureSets.js
+++ b/src/config/featureSets.js
@@ -25,7 +25,7 @@ export const featureChoices = [
   { title: "Prettier", value: "prettier", selected: true, description: "Code formatter" },
   { title: "Git Init", value: "git", selected: true, description: "Initialize repository" },
   { title: "SQLite Support", value: "sqlite", description: "Local database" },
-  { title: "AD/SSO Login Stub", value: "sso", description: "Placeholder auth" },
+  { title: "AD/SSO Login", value: "sso", description: "OAuth2 authentication" },
   { title: "Dark Mode Support", value: "darkmode", selected: true, description: "OS theme detection" },
   { title: "Frameless Window", value: "frameless", description: "Custom title bar" },
   

--- a/templates/with-sso/auth.js
+++ b/templates/with-sso/auth.js
@@ -1,22 +1,76 @@
-import { ipcMain } from 'electron';
+import { ipcMain, BrowserWindow, session } from 'electron';
 
-/**
- * Placeholder authentication handler used by the SSO template.
- *
- * This file intentionally contains **no real authentication logic** so that
- * applications do not ship with insecure default credentials.
- * Replace this entire file with your organisation's SSO/AD integration before
- * distributing your app.
- */
-ipcMain.handle('auth-login', async () => {
-  console.warn(
-    '[SSO] Placeholder auth handler invoked. Replace templates/with-sso/auth.js with real integration.'
+const {
+  SSO_AUTH_URL,
+  SSO_TOKEN_URL,
+  SSO_CLIENT_ID,
+  SSO_CLIENT_SECRET,
+  SSO_REDIRECT_URI = 'http://localhost:4280/callback'
+} = process.env;
+
+function isConfigured() {
+  return (
+    SSO_AUTH_URL &&
+    SSO_TOKEN_URL &&
+    SSO_CLIENT_ID &&
+    SSO_CLIENT_SECRET
   );
+}
 
-  // Always fail to enforce replacing this placeholder implementation.
-  return {
-    success: false,
-    error:
-      'Authentication placeholder - replace templates/with-sso/auth.js with real SSO integration.'
-  };
+function buildAuthUrl() {
+  const url = new URL(SSO_AUTH_URL);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', SSO_CLIENT_ID);
+  url.searchParams.set('redirect_uri', SSO_REDIRECT_URI);
+  return url.toString();
+}
+
+async function exchangeCodeForToken(code) {
+  const res = await fetch(SSO_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      client_id: SSO_CLIENT_ID,
+      client_secret: SSO_CLIENT_SECRET,
+      redirect_uri: SSO_REDIRECT_URI
+    })
+  });
+  if (!res.ok) {
+    throw new Error(`Token request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+ipcMain.handle('auth-login', async () => {
+  if (!isConfigured()) {
+    return { success: false, error: 'SSO environment variables not configured' };
+  }
+
+  return new Promise((resolve) => {
+    const win = new BrowserWindow({
+      width: 500,
+      height: 650,
+      webPreferences: { nodeIntegration: false }
+    });
+    win.loadURL(buildAuthUrl());
+
+    const filter = { urls: [`${SSO_REDIRECT_URI}*`] };
+    const handler = async (details) => {
+      const url = new URL(details.url);
+      const code = url.searchParams.get('code');
+      if (code) {
+        session.defaultSession.webRequest.onBeforeRequest(filter, null);
+        win.destroy();
+        try {
+          const token = await exchangeCodeForToken(code);
+          resolve({ success: true, token });
+        } catch (err) {
+          resolve({ success: false, error: err.message });
+        }
+      }
+    };
+    session.defaultSession.webRequest.onBeforeRequest(filter, handler);
+  });
 });


### PR DESCRIPTION
## Summary
- replace SSO stub with OAuth2 implementation
- update README to describe SSO login
- update feature description for SSO
- revise maintainer notes about SSO

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864053c6724832f9ec29372182fe37c