### PR TITLE
Add CLI flag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ create-electron-app my-app --help
 create-electron-app my-app
 ```
 
+### CLI flags
+
+Use `--help` to display usage information or `--version` to print the installed version.
+
+```bash
+create-electron-app --help
+create-electron-app --version
+```
+
+Running `create-electron-app` with no arguments starts the interactive wizard.
+
 The wizard walks you through:
 
 - Project metadata (name, author, license, description)


### PR DESCRIPTION
## Summary
- document `--help` and `--version` flags
- explain that running with no arguments launches the wizard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68640a6b5c3c832f93fdf588e10fceb5