### PR TITLE
Add dark mode feature support

### DIFF
--- a/templates/base/src/App.tsx
+++ b/templates/base/src/App.tsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 export default function App() {
+  useEffect(() => {
+    window.api?.on('darkmode-updated', (isDark: boolean) => {
+      console.log('dark mode changed', isDark);
+    });
+  }, []);
   return (
     <div style={{ padding: 20 }}>
       <h1>Hello from Electron + React + Vite!</h1>

--- a/templates/base/src/main.ts
+++ b/templates/base/src/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow } from "electron";
 import path from "path";
 import { fileURLToPath } from "url";
+{{DARKMODE_IMPORT}}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/templates/with-frameless/src/App.tsx
+++ b/templates/with-frameless/src/App.tsx
@@ -1,7 +1,12 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import WindowControls from './components/WindowControls';
 
 export default function App() {
+  useEffect(() => {
+    window.api?.on('darkmode-updated', (isDark: boolean) => {
+      console.log('dark mode changed', isDark);
+    });
+  }, []);
   return (
     <>
       <WindowControls />

--- a/templates/with-frameless/src/main.ts
+++ b/templates/with-frameless/src/main.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain } from "electron";
 import path from "path";
 import { fileURLToPath } from "url";
+{{DARKMODE_IMPORT}}
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/test/darkmode.test.js
+++ b/test/darkmode.test.js
@@ -1,0 +1,46 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, existsSync, rmSync, chmodSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("darkmode feature", () => {
+  test("copies darkmode files and injects import", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "dark-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: [],
+        features: ["darkmode"],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const file = join(outDir, "src", "darkmode.js");
+      assert.ok(existsSync(file));
+      const mainFile = readFileSync(join(outDir, "src", "main.ts"), "utf8");
+      assert.match(mainFile, /import '\.\/darkmode\.js';/);
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- inject `import './darkmode.js'` when dark mode enabled
- ship darkmode file to generated src
- listen for `darkmode-updated` messages in renderer
- test generator dark mode workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68640d6b03b0832fa59d57f3e4b302dc