### PR TITLE
Fix stray braces causing syntax issues

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -213,9 +213,6 @@ if (extraImports.length > 0) {
   }
 }
 
-    }
-  }
-
   // Include electron-builder config if dist script selected
   if (answers.scripts.includes("dist")) {
     const builderTemplate = path.resolve(__dirname, "../templates/with-dist");


### PR DESCRIPTION
## Summary
- remove stray closing braces in `src/generator.js`
- verify file syntax with `node --check`

## Testing
- `node --check src/generator.js`
- `npm test` *(fails: tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_686412836350832fb9ffcb79e772a26b