### PR TITLE
Auto-enable preload when frameless selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 - **SQLite** – optional local database integration
 - **SSO login** – enterprise authentication via OAuth2
 - **Dark mode** – aligns with the native OS theme
-- **Frameless window** – custom controls via `src/components/WindowControls.tsx`
+- **Frameless window** – custom controls via `src/components/WindowControls.tsx`. Selecting this option automatically enables the **Preload** feature.
 - **Packaging** – electron-builder configuration
 - **Predefined npm scripts** – dev, build, lint, format, and more
 - Fully extensible with custom templates
@@ -87,7 +87,7 @@ The wizard walks you through:
 
 - Project metadata (name, author, license, description)
 - **Mandatory features** (React, TypeScript, Electron)
-- Optional features like Preload, SQLite, SSO and dark mode
+- Optional features like Preload, SQLite, SSO and dark mode. Choosing the frameless window option will enable Preload automatically.
 - Dev tooling (ESLint, Prettier)
 - Packaging scripts
 - Window and UI options

--- a/src/generator.js
+++ b/src/generator.js
@@ -213,8 +213,6 @@ if (extraImports.length > 0) {
   }
 }
 
-    }
-  }
 
   // Include electron-builder config if dist script selected
   if (answers.scripts.includes("dist")) {

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -127,6 +127,13 @@ export async function createAppWizard() {
     ...mandatory.map(f => f.value),
     ...(featurePrompt.selected || []),
   ];
+  if (
+    answers.features.includes("frameless") &&
+    !answers.features.includes("preload")
+  ) {
+    answers.features.push("preload");
+    info(chalk.yellow("Preload enabled automatically for frameless windows."));
+  }
   printDivider();
 
   printStepHeader(3, totalSteps, "Dev Script Options");


### PR DESCRIPTION
## Summary
- automatically enable `preload` when `frameless` is chosen in the wizard
- mention this behaviour in README
- clean up stray braces in generator.js to keep file valid

## Testing
- `npm test` *(fails: darkmode feature, scaffoldProject darkmode, scaffoldProject sso, tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6864128dc50c832fb6ac872f08c11959