### PR TITLE
Fix SSO import path

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -223,9 +223,7 @@ const extraImports = [];
 
 
 if (answers.features.includes("sso")) {
-
   extraImports.push("../auth.js");
-  extraImports.push("./auth.js");
 }
 
 if (extraImports.length > 0) {

--- a/test/features.test.js
+++ b/test/features.test.js
@@ -36,7 +36,8 @@ describe("scaffoldProject darkmode", () => {
       assert.ok(existsSync(file));
       const mainFile = join(outDir, "src", "main.ts");
       const main = readFileSync(mainFile, "utf8");
-      assert.match(main, /import .*['\"]\.\/darkmode\.js['\"]/);
+      const dmMatches = main.match(/import '\.\/darkmode\.js';/g) || [];
+      assert.equal(dmMatches.length, 1);
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;
@@ -69,7 +70,8 @@ describe("scaffoldProject sso", () => {
       assert.ok(existsSync(file));
       const mainFile = join(outDir, "src", "main.ts");
       const main = readFileSync(mainFile, "utf8");
-      assert.match(main, /import .*['\"]\.\.\/auth\.js['\"]/);
+      const matches = main.match(/import '\.\.\/auth\.js';/g) || [];
+      assert.equal(matches.length, 1);
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;

--- a/test/sso.test.js
+++ b/test/sso.test.js
@@ -35,7 +35,8 @@ describe("scaffoldProject", () => {
       const authFile = join(outDir, "auth.js");
       assert.ok(existsSync(authFile));
       const mainContent = readFileSync(join(outDir, "src", "main.ts"), "utf8");
-      assert.match(mainContent, /import\s+['"]\.\/auth\.js['"]/);
+      const matches = mainContent.match(/import '\.\.\/auth\.js';/g) || [];
+      assert.equal(matches.length, 1);
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;


### PR DESCRIPTION
## Summary
- remove duplicate SSO import
- check for exactly one auth.js import in tests

## Testing
- `npm test --silent` *(fails: darkmode feature and tsconfig tests)*

------
https://chatgpt.com/codex/tasks/task_e_686419acbdc0832f81f5f51775151624