### PR TITLE
Make dbinit optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint
 npm run format  # Run Prettier
 npm run reset   # Remove node_modules and reinstall
-npm run dbinit # Initialize the SQLite database
+npm run dbinit # Initialize the SQLite database (if included)
 npm run start   # Launch the compiled app
 ```
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -80,7 +80,7 @@ export async function scaffoldProject(answers) {
     }
   }
 
-  if (answers.features.includes("sqlite")) {
+  if (answers.scripts.includes("dbinit")) {
     pkg.scripts["dbinit"] = fullScriptMap.dbinit;
   }
   pkg.dependencies = { ...dependencies };
@@ -199,7 +199,10 @@ export async function scaffoldProject(answers) {
 
   // Copy special feature files
   if (answers.features.includes("darkmode")) {
-    const dmSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const dmSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     try {
       await fs.copyFile(dmSrc, path.join(outDir, "darkmode.js"));
       await ensureDir(path.join(outDir, "src"));
@@ -247,7 +250,10 @@ if (extraImports.length > 0) {
 
   // Handle darkmode feature separately
   if (answers.features.includes("darkmode")) {
-    const darkSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const darkSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     const darkDestSrc = path.join(outDir, "src", "darkmode.js");
     const darkDestRoot = path.join(outDir, "darkmode.js");
     try {

--- a/test/dbinit.test.js
+++ b/test/dbinit.test.js
@@ -1,0 +1,72 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("dbinit script", () => {
+  test("added when selected", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "sqlite-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: ["dbinit"],
+        features: ["sqlite"],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.ok(pkg.scripts.dbinit);
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+
+  test("omitted when not selected", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "no-script-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: [],
+        features: ["sqlite"],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.ok(!pkg.scripts.dbinit);
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `dbinit` script only when selected
- fix darkmode template path
- clarify README about optional script
- test `dbinit` script handling

## Testing
- `npm test --silent` *(fails: tsconfig suite)*

------
https://chatgpt.com/codex/tasks/task_e_686419bae688832fa0ad6834b96b53b7