### PR TITLE
Enable preload with darkmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - **Git initialization** – with an initial commit
 - **SQLite** – optional local database integration
 - **SSO login** – enterprise authentication via OAuth2
-- **Dark mode** – aligns with the native OS theme
+- **Dark mode** – aligns with the native OS theme. Selecting this option automatically enables the **Preload** feature.
 - **Frameless window** – custom controls via `src/components/WindowControls.tsx`. Selecting this option automatically enables the **Preload** feature.
 - **Packaging** – electron-builder configuration
 - **Predefined npm scripts** – dev, build, lint, format, and more
@@ -87,7 +87,7 @@ The wizard walks you through:
 
 - Project metadata (name, author, license, description)
 - **Mandatory features** (React, TypeScript, Electron)
-- Optional features like Preload, SQLite, SSO and dark mode. Choosing the frameless window option will enable Preload automatically.
+- Optional features like Preload, SQLite, SSO and dark mode. Choosing the frameless window or dark mode option will enable Preload automatically.
 - Dev tooling (ESLint, Prettier)
 - Packaging scripts
 - Window and UI options

--- a/src/generator.js
+++ b/src/generator.js
@@ -199,7 +199,10 @@ export async function scaffoldProject(answers) {
 
   // Copy special feature files
   if (answers.features.includes("darkmode")) {
-    const dmSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const dmSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     try {
       await fs.copyFile(dmSrc, path.join(outDir, "darkmode.js"));
       await ensureDir(path.join(outDir, "src"));
@@ -247,7 +250,10 @@ if (extraImports.length > 0) {
 
   // Handle darkmode feature separately
   if (answers.features.includes("darkmode")) {
-    const darkSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const darkSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     const darkDestSrc = path.join(outDir, "src", "darkmode.js");
     const darkDestRoot = path.join(outDir, "darkmode.js");
     try {

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -134,6 +134,13 @@ export async function createAppWizard() {
     answers.features.push("preload");
     info(chalk.yellow("Preload enabled automatically for frameless windows."));
   }
+  if (
+    answers.features.includes("darkmode") &&
+    !answers.features.includes("preload")
+  ) {
+    answers.features.push("preload");
+    info(chalk.yellow("Preload enabled automatically for dark mode."));
+  }
   printDivider();
 
   printStepHeader(3, totalSteps, "Dev Script Options");

--- a/test/tsc.test.js
+++ b/test/tsc.test.js
@@ -44,7 +44,7 @@ describe("tsconfig", () => {
           "declare module 'react-dom';",
           "declare module 'react-dom/client';",
           "declare module 'vite/client';",
-          "declare global { interface Window { api: any } }",
+          "declare global { interface Window { api?: any } }",
           "export {};",
           "",
         ].join("\n")

--- a/test/wizard-darkmode.test.js
+++ b/test/wizard-darkmode.test.js
@@ -1,0 +1,49 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import prompts from "prompts";
+import { createAppWizard } from "../src/wizard.js";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("wizard darkmode", () => {
+  test("selecting darkmode adds preload and keeps file", async () => {
+    prompts.inject([
+      "wiz-app",
+      "Title",
+      "",
+      "",
+      "MIT",
+      ["darkmode"],
+      ["dev"],
+      true,
+    ]);
+    const answers = await createAppWizard();
+    assert.ok(answers.features.includes("preload"));
+
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const { outDir } = await scaffoldProject(answers);
+      assert.ok(existsSync(join(outDir, "src", "preload.ts")));
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- auto-enable preload when darkmode is selected in the wizard
- document that darkmode also activates preload
- fix darkmode template path
- adjust tsc test shim
- add regression test for wizard darkmode preload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686419b4ceac832f9a192e9989b31c05