### PR TITLE
Fix frameless API path

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -199,7 +199,10 @@ export async function scaffoldProject(answers) {
 
   // Copy special feature files
   if (answers.features.includes("darkmode")) {
-    const dmSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const dmSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     try {
       await fs.copyFile(dmSrc, path.join(outDir, "darkmode.js"));
       await ensureDir(path.join(outDir, "src"));
@@ -247,7 +250,10 @@ if (extraImports.length > 0) {
 
   // Handle darkmode feature separately
   if (answers.features.includes("darkmode")) {
-    const darkSrc = path.resolve(__dirname, "../templates/with-darkmode/darkmode.js");
+    const darkSrc = path.resolve(
+      __dirname,
+      "../templates/with-darkmode/src/darkmode.js"
+    );
     const darkDestSrc = path.join(outDir, "src", "darkmode.js");
     const darkDestRoot = path.join(outDir, "darkmode.js");
     try {

--- a/templates/base/src/global.d.ts
+++ b/templates/base/src/global.d.ts
@@ -1,7 +1,7 @@
 
 declare global {
   interface Window {
-    api?: any;
+    api: any;
   }
 }
 export {};

--- a/templates/with-frameless/src/components/WindowControls.tsx
+++ b/templates/with-frameless/src/components/WindowControls.tsx
@@ -7,21 +7,21 @@ style={{ WebkitAppRegion: "drag", backgroundColor: "transparent" }}
     >
       <button
         className="px-2"
-        onClick={() => window.windowControls.minimize()}
+        onClick={() => window.api?.windowControls.minimize()}
         style={{ WebkitAppRegion: "no-drag" }}
       >
         –
       </button>
       <button
         className="px-2"
-        onClick={() => window.windowControls.maximize()}
+        onClick={() => window.api?.windowControls.maximize()}
         style={{ WebkitAppRegion: "no-drag" }}
       >
         ⬜
       </button>
       <button
         className="px-2 text-red-500"
-        onClick={() => window.windowControls.close()}
+        onClick={() => window.api?.windowControls.close()}
         style={{ WebkitAppRegion: "no-drag" }}
       >
         ✕

--- a/templates/with-frameless/src/global.d.ts
+++ b/templates/with-frameless/src/global.d.ts
@@ -6,8 +6,10 @@ export interface WindowControls {
 
 declare global {
   interface Window {
-    windowControls: WindowControls;
-    api?: any;
+    api?: {
+      windowControls: WindowControls;
+      [key: string]: any;
+    };
   }
 }
 

--- a/templates/with-frameless/src/preload.ts
+++ b/templates/with-frameless/src/preload.ts
@@ -24,7 +24,7 @@ const windowControls = {
   close: () => ipcRenderer.send('window:close'),
 };
 
-// Single contextBridge exposure
+// Single contextBridge exposure. Renderer access: window.api.windowControls
 contextBridge.exposeInMainWorld('api', {
   ...api,
   windowControls,


### PR DESCRIPTION
## Summary
- ensure window controls are accessed via `window.api.windowControls`
- update typings for the frameless preload API
- adjust generator to copy darkmode template from `src`
- make `api` required in base typings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686419b150bc832f8350a8d7732afd8f