### PR TITLE
Add Node test script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ npm run build   # TypeScript compile and Vite build
 npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint
 npm run format  # Run Prettier
+npm test        # Run Node.js tests
 npm run reset   # Remove node_modules and reinstall
 npm run dbinit # Initialize the SQLite database (if included)
 npm run start   # Launch the compiled app

--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -7,6 +7,7 @@ export const scriptOptions = [
   { title: "npm run clean → Remove build/dist/cache folders", value: "clean", description: "Clear output" },
   { title: "npm run lint → Run ESLint", value: "lint", selected: true, description: "Check code" },
   { title: "npm run format → Run Prettier", value: "format", selected: true, description: "Format code" },
+  { title: "npm test → Run Node.js tests", value: "test", selected: true, description: "node --test" },
   { title: "npm run reset → Clean + reinstall deps", value: "reset", description: "Full reinstall" },
   { title: "npm run db:init → Initialize SQLite schema", value: "dbinit", description: "Setup DB" },
   { title: "npm run start → Launch production build", value: "start", description: "Run compiled app" }
@@ -19,6 +20,7 @@ export const fullScriptMap = {
   clean: "rimraf dist build .cache",
   lint: "eslint . --ext .ts,.tsx",
   format: "prettier --write .",
+  test: "node --test",
   reset: "rimraf node_modules && npm install",
   dbinit: "node scripts/init-db.js",
   start: "node dist/main.js"


### PR DESCRIPTION
## Summary
- add `test` entry to `scriptOptions` and map it to `node --test`
- document `npm test` command in README

## Testing
- `npm test` *(fails: tsc runs cleanly for minimal setup)*

------
https://chatgpt.com/codex/tasks/task_e_68641cd594b0832f915299eb193ab061