### PR TITLE
Make global types optional

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -275,8 +275,17 @@ if (extraImports.length > 0) {
     }
   }
 
-  // Remove global.d.ts from tsconfig if not present
+  // Remove global.d.ts when preload feature not selected
   const globalTypesPath = path.join(outDir, "src", "global.d.ts");
+  if (!answers.features.includes("preload")) {
+    try {
+      await fs.rm(globalTypesPath, { force: true });
+    } catch {
+      // ignore errors
+    }
+  }
+
+  // Remove global.d.ts from tsconfig if not present
   try {
     await fs.access(globalTypesPath);
   } catch {

--- a/test/global-types.test.js
+++ b/test/global-types.test.js
@@ -1,0 +1,45 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("global.d.ts handling", () => {
+  test("file removed when preload feature not selected", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "nopreload-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: [],
+        features: [],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      assert.ok(!existsSync(join(outDir, "src", "global.d.ts")));
+      const tsconfig = JSON.parse(readFileSync(join(outDir, "tsconfig.json"), "utf8"));
+      assert.ok(!tsconfig.include.includes("src/global.d.ts"));
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- remove `src/global.d.ts` when the `preload` feature isn't selected
- keep `tsconfig.json` in sync if the global types file is removed
- test that `global.d.ts` is omitted when not using the `preload` feature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686420ee6a70832fbcc464b7fcf0fc65