### PR TITLE
Replace enquirer with prompts in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ### 🔰 CLI OVERVIEW
 
 * CLI Name: `create-electron-app` (global binary installed via `bin/index.js`)
-* Tech: Node.js (ESM), `enquirer` for prompts, modular scaffold logic
+* Tech: Node.js (ESM), `prompts` for prompts, modular scaffold logic
 * Run anywhere from terminal: `create-electron-app`
 * Generates fully working Electron app (Vite+React+TS) into CWD
 * Output folder: `${cwd}/${appName}`


### PR DESCRIPTION
## Summary
- update CLI documentation to refer to `prompts` instead of `enquirer`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864243d8750832f8c4af25f5c716c47