### PR TITLE
Update dev script to use concurrently

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Each feature corresponds to `templates/with-<feature>/`:
 
 ```json
 "scripts": {
-  "dev": "vite --config vite.config.js && electron .",
+  "dev": "concurrently \"cross-env NODE_ENV=development vite --config vite.config.js\" \"cross-env NODE_ENV=development electron .\"",
   "build": "tsc && vite build",
   "dist": "electron-builder",
   "clean": "rimraf dist build .cache",

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After completion, your project folder includes:
 The generated `package.json` includes helpful commands:
 
 ```bash
-npm run dev     # Start Vite and Electron in watch mode
+npm run dev     # Start Vite and Electron simultaneously in watch mode
 npm run build   # TypeScript compile and Vite build
 npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint

--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -14,7 +14,7 @@ export const scriptOptions = [
 ];
 
 export const fullScriptMap = {
-  dev: "cross-env NODE_ENV=development vite --config vite.config.js && cross-env NODE_ENV=development electron .",
+  dev: "concurrently \"cross-env NODE_ENV=development vite --config vite.config.js\" \"cross-env NODE_ENV=development electron .\"",
   build: "tsc && vite build",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",

--- a/src/generator.js
+++ b/src/generator.js
@@ -106,6 +106,7 @@ export async function scaffoldProject(answers) {
   }
   if (answers.scripts.includes("dev")) {
     pkg.devDependencies["cross-env"] = "^7.0.3";
+    pkg.devDependencies["concurrently"] = "^8.2.0";
   }
 
   try {


### PR DESCRIPTION
## Summary
- use `concurrently` for the dev command
- include `concurrently` when generating projects
- update docs with the new command

## Testing
- `npm test`
- `node` script to scaffold a project and print the dev script

------
https://chatgpt.com/codex/tasks/task_e_68642461be14832f8de5a16a72e8da3c