### PR TITLE
Fix build script order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@ Each feature corresponds to `templates/with-<feature>/`:
 ```json
 "scripts": {
   "dev": "vite --config vite.config.js && electron .",
-  "build": "tsc && vite build",
+  "build": "vite build && tsc",
   "dist": "electron-builder",
   "clean": "rimraf dist build .cache",
   "lint": "eslint . --ext .ts,.tsx",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The generated `package.json` includes helpful commands:
 
 ```bash
 npm run dev     # Start Vite and Electron in watch mode
-npm run build   # TypeScript compile and Vite build
+npm run build   # Vite build then TypeScript compile
 npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint
 npm run format  # Run Prettier

--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -15,7 +15,7 @@ export const scriptOptions = [
 
 export const fullScriptMap = {
   dev: "cross-env NODE_ENV=development vite --config vite.config.js && cross-env NODE_ENV=development electron .",
-  build: "tsc && vite build",
+  build: "vite build && tsc",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",
   lint: "eslint . --ext .ts,.tsx",

--- a/test/build-script.test.js
+++ b/test/build-script.test.js
@@ -1,0 +1,44 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("build script", () => {
+  test("build script runs vite before tsc", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "order-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: ["build"],
+        features: [],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.equal(pkg.scripts.build, "vite build && tsc");
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- fix build script ordering so Vite output doesn't remove TypeScript build
- document build step change in readme and agents notes
- test the generated build script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686424a882f8832fa67e394a63d82e59