### PR TITLE
Add Prettier template and test

### DIFF
--- a/templates/with-prettier/.prettierrc
+++ b/templates/with-prettier/.prettierrc
@@ -3,5 +3,6 @@
   "semi": true,
   "trailingComma": "es5",
   "printWidth": 80,
-  "tabWidth": 2
+  "tabWidth": 2,
+  "arrowParens": "avoid"
 }

--- a/test/wizard-scripts.test.js
+++ b/test/wizard-scripts.test.js
@@ -1,7 +1,25 @@
 import { describe, test } from "node:test";
 import { strict as assert } from "assert";
+import {
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  chmodSync,
+  existsSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import prompts from "prompts";
 import { createAppWizard } from "../src/wizard.js";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
 
 describe("wizard script dependencies", () => {
   test("lint script auto-enables eslint feature", async () => {
@@ -32,5 +50,21 @@ describe("wizard script dependencies", () => {
     ]);
     const answers = await createAppWizard();
     assert.ok(answers.features.includes("prettier"));
+
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const { outDir } = await scaffoldProject(answers);
+      assert.ok(existsSync(join(outDir, ".prettierrc")));
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- define Prettier formatting defaults in the Prettier template
- test that scaffolding with the format script copies `.prettierrc`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68642c5a1150832f874710269d830559