### PR TITLE
Update feature docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,11 @@ Each feature corresponds to `templates/with-<feature>/`:
 * `electron`: always included
 * `preload`: adds `src/preload.ts`
 * `eslint`: `.eslintrc.js`
-* `prettier`: `.prettierrc`
+* `prettier`: `.prettierrc`, `.prettierignore`
 * `sqlite`: `sqlite3`, `scripts/init-db.js`
 * `sso`: creates login handler for AD/SSO
-* `darkmode`: adds `darkmode.js`
+* `darkmode`: adds `darkmode.js` (auto-enables `preload`)
+* `frameless`: custom window controls (auto-enables `preload`)
 
 ---
 


### PR DESCRIPTION
## Summary
- mention `.prettierignore` in feature table
- document that `darkmode` and `frameless` enable `preload`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686437542468832f845d708e49db02d5