### PR TITLE
Fix production load logic

### DIFF
--- a/templates/base/src/main.ts
+++ b/templates/base/src/main.ts
@@ -25,10 +25,11 @@ function createWindow() {
     },
   });
 
-  win.loadURL("http://localhost:3000");
-
   if (process.env.NODE_ENV === "development") {
+    win.loadURL("http://localhost:3000");
     win.webContents.openDevTools();
+  } else {
+    win.loadFile(path.join(__dirname, "../dist/index.html"));
   }
 }
 

--- a/templates/with-frameless/src/main.ts
+++ b/templates/with-frameless/src/main.ts
@@ -25,10 +25,11 @@ function createWindow() {
     },
   });
 
-  win.loadURL("http://localhost:3000");
-
   if (process.env.NODE_ENV === "development") {
+    win.loadURL("http://localhost:3000");
     win.webContents.openDevTools();
+  } else {
+    win.loadFile(path.join(__dirname, "../dist/index.html"));
   }
 }
 


### PR DESCRIPTION
## Summary
- load the dev URL only during development
- otherwise load `dist/index.html`
- keep devtools in development only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68643c3948c8832f9e7cd4dffbf84422