### PR TITLE
Expose getDarkMode API

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ const allowedReceiveChannels = ['fromMain', 'settings:changed'];
 
 This pattern keeps the IPC surface minimal and secure.
 
+## Dark Mode API
+
+When the dark mode feature is selected, the preload script provides a
+`getDarkMode()` method. It returns a promise resolving to `true` when the
+operating system is using a dark theme:
+
+```ts
+const isDark = await window.api.getDarkMode();
+```
+
+Listen for the `darkmode-updated` event to react to changes:
+
+```ts
+window.api.on('darkmode-updated', (isDark) => {
+  // update UI
+});
+```
+
 ## Environment Variables
 
 The SSO feature relies on several variables:

--- a/templates/base/src/App.tsx
+++ b/templates/base/src/App.tsx
@@ -1,15 +1,20 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function App() {
+  const [isDark, setIsDark] = useState(false);
+
   useEffect(() => {
-    window.api?.on('darkmode-updated', (isDark: boolean) => {
-      console.log('dark mode changed', isDark);
+    window.api?.getDarkMode?.().then((dark: boolean) => setIsDark(dark));
+    window.api?.on('darkmode-updated', (dark: boolean) => {
+      setIsDark(dark);
     });
   }, []);
+
   return (
     <div style={{ padding: 20 }}>
       <h1>Hello from Electron + React + Vite!</h1>
       <p>Your app is running.</p>
+      <p>Current theme: {isDark ? 'dark' : 'light'}</p>
     </div>
   );
 }

--- a/templates/base/src/global.d.ts
+++ b/templates/base/src/global.d.ts
@@ -1,7 +1,12 @@
 
 declare global {
   interface Window {
-    api: any;
+    api: {
+      getDarkMode?: () => Promise<boolean>;
+      on: (channel: string, listener: (...args: unknown[]) => void) => void;
+      send: (channel: string, data?: unknown) => void;
+      [key: string]: any;
+    };
   }
 }
 export {};

--- a/templates/base/src/preload.ts
+++ b/templates/base/src/preload.ts
@@ -17,6 +17,9 @@ export const api = {
       ipcRenderer.on(channel, (_event, ...args) => listener(...args));
     }
   },
+  getDarkMode() {
+    return ipcRenderer.invoke('darkmode-get');
+  },
 };
 
 contextBridge.exposeInMainWorld('api', api);

--- a/templates/with-frameless/src/App.tsx
+++ b/templates/with-frameless/src/App.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import WindowControls from './components/WindowControls';
 
 export default function App() {
+  const [isDark, setIsDark] = useState(false);
+
   useEffect(() => {
-    window.api?.on('darkmode-updated', (isDark: boolean) => {
-      console.log('dark mode changed', isDark);
+    window.api?.getDarkMode?.().then((dark: boolean) => setIsDark(dark));
+    window.api?.on('darkmode-updated', (dark: boolean) => {
+      setIsDark(dark);
     });
   }, []);
   return (
@@ -13,6 +16,7 @@ export default function App() {
       <div style={{ padding: 20 }}>
         <h1>Hello from Electron + React + Vite!</h1>
         <p>Your app is running.</p>
+        <p>Current theme: {isDark ? 'dark' : 'light'}</p>
       </div>
     </>
   );

--- a/templates/with-frameless/src/global.d.ts
+++ b/templates/with-frameless/src/global.d.ts
@@ -16,6 +16,9 @@ declare global {
   interface Window {
     api?: {
       windowControls: WindowControls;
+      getDarkMode?: () => Promise<boolean>;
+      on: (channel: string, listener: (...args: unknown[]) => void) => void;
+      send: (channel: string, data?: unknown) => void;
       [key: string]: any;
     };
   }

--- a/templates/with-frameless/src/preload.ts
+++ b/templates/with-frameless/src/preload.ts
@@ -15,6 +15,9 @@ const api = {
       ipcRenderer.on(channel, (_event, ...args) => listener(...args));
     }
   },
+  getDarkMode() {
+    return ipcRenderer.invoke('darkmode-get');
+  },
 };
 
 // Frameless window controls


### PR DESCRIPTION
## Summary
- expose `getDarkMode()` via preload scripts
- query `getDarkMode()` on startup in example React apps
- expand global TypeScript definitions
- document the dark mode API in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643c4376ec832f831bea59f9772d38