### PR TITLE
Add package manager prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The wizard walks you through:
 - Project metadata (name, author, license, description)
 - **Mandatory features** (React, TypeScript, Electron)
 - Optional features like Preload, SQLite, SSO and dark mode. Choosing the frameless window or dark mode option will enable Preload automatically.
+- Choose your preferred package manager (npm, yarn or pnpm)
 - Dev tooling (ESLint, Prettier)
 - Packaging scripts
 - Window and UI options

--- a/bin/index.js
+++ b/bin/index.js
@@ -34,6 +34,7 @@ if (args.includes("-v") || args.includes("--version")) {
 if (args.includes("-h") || args.includes("--help")) {
   console.log("Usage: create-electron-app [options]\n" +
     "Run without options to start the interactive wizard.\n" +
+    "The wizard lets you choose npm, yarn or pnpm for dependency installation.\n" +
     "  -h, --help     Show this help\n" +
     "  -v, --version  Show CLI version");
   process.exit(0);

--- a/src/generator.js
+++ b/src/generator.js
@@ -307,13 +307,14 @@ if (extraImports.length > 0) {
     throw new Error(`Template token rendering failed: ${e.message}`);
   }
 
-  // Install dependencies
+  // Install dependencies using chosen package manager
+  const pm = answers.packageManager || "npm";
   try {
     info("🔧 Installing dependencies...");
-    await execa("npm", ["install"], { cwd: outDir, stdio: "inherit" });
+    await execa(pm, ["install"], { cwd: outDir, stdio: "inherit" });
   } catch (e) {
     await cleanupProject();
-    throw new Error(`npm install failed: ${e.message}. Project directory cleaned up.`);
+    throw new Error(`${pm} install failed: ${e.message}. Project directory cleaned up.`);
   }
 
   // Initialize Git repo if selected

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -40,6 +40,7 @@ Name: ${answers.appName}
 Title: ${answers.title}
 Author: ${answers.author}
 License: ${answers.license}
+Package Manager: ${answers.packageManager}
 
 ${chalk.underline("Features")}
 ${featureList}
@@ -53,7 +54,7 @@ ${scriptList}
 
 export async function createAppWizard() {
   const answers = {};
-  const totalSteps = 4;
+  const totalSteps = 5;
 
   const onCancel = () => {
     console.log("Aborted.");
@@ -143,7 +144,25 @@ export async function createAppWizard() {
   }
   printDivider();
 
-  printStepHeader(3, totalSteps, "Dev Script Options");
+  printStepHeader(3, totalSteps, "Package Manager");
+  const pmPrompt = await prompts(
+    {
+      type: "select",
+      name: "packageManager",
+      message: chalk.cyan("Choose your package manager:"),
+      choices: [
+        { title: "npm", value: "npm" },
+        { title: "yarn", value: "yarn" },
+        { title: "pnpm", value: "pnpm" },
+      ],
+      initial: 0,
+    },
+    { onCancel }
+  );
+  Object.assign(answers, pmPrompt);
+  printDivider();
+
+  printStepHeader(4, totalSteps, "Dev Script Options");
   const scriptPrompt = await prompts({
     type: "multiselect",
     name: "scripts",
@@ -171,7 +190,7 @@ export async function createAppWizard() {
   }
   printDivider();
 
-  printStepHeader(4, totalSteps, "Summary & Confirm");
+  printStepHeader(5, totalSteps, "Summary & Confirm");
   renderSummary(answers);
 
   const confirm = await prompts({

--- a/test/wizard-darkmode.test.js
+++ b/test/wizard-darkmode.test.js
@@ -24,6 +24,7 @@ describe("wizard darkmode", () => {
       "",
       "MIT",
       ["darkmode"],
+      "npm",
       ["dev"],
       true,
     ]);

--- a/test/wizard-frameless.test.js
+++ b/test/wizard-frameless.test.js
@@ -24,6 +24,7 @@ describe("wizard frameless", () => {
       "", // author
       "MIT", // license
       ["frameless"], // features
+      "npm",
       ["dev"], // scripts
       true, // confirm
     ]);

--- a/test/wizard-scripts.test.js
+++ b/test/wizard-scripts.test.js
@@ -30,6 +30,7 @@ describe("wizard script dependencies", () => {
       "",
       "MIT",
       [],
+      "npm",
       ["lint"],
       true,
     ]);
@@ -45,6 +46,7 @@ describe("wizard script dependencies", () => {
       "",
       "MIT",
       [],
+      "npm",
       ["format"],
       true,
     ]);


### PR DESCRIPTION
## Summary
- add wizard step to choose a package manager
- install deps using chosen command
- mention package manager choice in help text and README
- update tests for the new wizard step

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68643c482bfc832f9d8d1978ab128be1