### PR TITLE
Gate pretest with SKIP_SETUP and document setup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ Contributions and issues welcome! Please:
 * Create feature branches
 * Submit pull requests with tests and documentation updates
 * Adhere to existing code style and lint rules
+* Run `npm install` once before executing the test suite. The `pretest` script
+  will reinstall dependencies unless the `SKIP_SETUP` environment variable is
+  set.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "node bin/index.js",
     "test": "node --test",
     "setup": "npm install",
-    "pretest": "npm run setup"
+    "pretest": "node -e \"if(!process.env.SKIP_SETUP){require('child_process').execSync('npm run setup',{stdio:'inherit'})}\""
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- allow skipping pretest install with `SKIP_SETUP`
- document running `npm install` before the test suite

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68644017d56c832f9f4fb508c415ab4f