### PR TITLE
Add TypeScript watch to dev workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Each feature corresponds to `templates/with-<feature>/`:
 ```json
 "scripts": {
 
-  "dev": "cross-env NODE_ENV=development concurrently \"vite --config vite.config.js\" \"electron .\"",
+  "dev": "cross-env NODE_ENV=development concurrently \"tsc -w\" \"vite --config vite.config.js\" \"electron .\"",
   "build": "vite build && tsc",
   "dist": "electron-builder",
   "clean": "rimraf dist build .cache",
@@ -65,7 +65,7 @@ Each feature corresponds to `templates/with-<feature>/`:
 }
 ```
 
-*The `dev` script relies on the `concurrently` and `cross-env` packages to run Vite and Electron in parallel while setting `NODE_ENV`. Include these as development dependencies.*
+*The `dev` script relies on `concurrently` and `cross-env` to run `tsc -w`, Vite and Electron in parallel while setting `NODE_ENV`. Include these as development dependencies.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ After completion, your project folder includes:
 The generated `package.json` includes helpful commands:
 
 ```bash
-npm run dev     # Start Vite and Electron in watch mode
+npm run dev     # Start TypeScript, Vite and Electron in watch mode
 npm run build   # Vite build then TypeScript compile
 npm run dist    # Package installers via electron-builder
 npm run lint    # Run ESLint

--- a/src/config/scripts.js
+++ b/src/config/scripts.js
@@ -14,7 +14,7 @@ export const scriptOptions = [
 ];
 
 export const fullScriptMap = {
-  dev: "cross-env NODE_ENV=development concurrently \"vite --config vite.config.js\" \"electron .\"",
+  dev: "cross-env NODE_ENV=development concurrently \"tsc -w\" \"vite --config vite.config.js\" \"electron .\"",
   build: "vite build && tsc",
   dist: "electron-builder",
   clean: "rimraf dist build .cache",

--- a/src/generator.js
+++ b/src/generator.js
@@ -108,6 +108,10 @@ export async function scaffoldProject(answers) {
     pkg.devDependencies["cross-env"] = "^7.0.3";
     pkg.devDependencies["concurrently"] = "^8.2.0";
   }
+  if (answers.scripts.includes("dev") || answers.scripts.includes("build")) {
+    pkg.devDependencies["typescript"] = "^5.4.0";
+    pkg.devDependencies["@types/node"] = "^20.0.0";
+  }
 
   try {
     await fs.writeFile(

--- a/test/dev-script.test.js
+++ b/test/dev-script.test.js
@@ -1,0 +1,78 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("dev script", () => {
+  test("adds tsc watch and dev deps", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "dev-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: ["dev"],
+        features: [],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.equal(
+        pkg.scripts.dev,
+        "cross-env NODE_ENV=development concurrently \"tsc -w\" \"vite --config vite.config.js\" \"electron .\""
+      );
+      assert.ok(pkg.devDependencies.typescript);
+      assert.ok(pkg.devDependencies["@types/node"]);
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build script adds ts dev deps", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "build-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: ["build"],
+        features: [],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.ok(pkg.devDependencies.typescript);
+      assert.ok(pkg.devDependencies["@types/node"]);
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- run `tsc -w` alongside Vite and Electron when using `npm run dev`
- install `typescript` and `@types/node` when dev or build scripts are chosen
- document updated dev script
- add tests for the new script behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68644048d8fc832f920699e812f12782