### PR TITLE
Add Node version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Node.js **18+**
+- Node.js **18+** (the CLI exits with an error on older versions)
 - macOS, Windows and Linux are supported
 
 ---

--- a/bin/index.js
+++ b/bin/index.js
@@ -26,6 +26,12 @@ console.log(gradient.rainbow.multiline(title));
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "../package.json"), "utf8"));
 
+const [major] = process.versions.node.split('.').map(Number);
+if (major < 18) {
+  console.error('Node.js 18 or newer is required.');
+  process.exit(1);
+}
+
 const args = process.argv.slice(2);
 if (args.includes("-v") || args.includes("--version")) {
   console.log(`v${pkg.version}`);


### PR DESCRIPTION
## Summary
- require Node 18 in the CLI script
- note this behavior in the README Requirements section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864451aa318832f8370fdc2e103cfec