### PR TITLE
Add automatic preload injection

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -34,6 +34,15 @@ export async function scaffoldProject(answers) {
     throw new Error(`Target directory '${outDir}' exists and is not empty.`);
   }
 
+  // Ensure preload feature when required by other features
+  if (
+    (answers.features.includes("darkmode") || answers.features.includes("frameless")) &&
+    !answers.features.includes("preload")
+  ) {
+    answers.features.push("preload");
+    info("Preload feature enabled automatically.");
+  }
+
   // Define required dependencies explicitly
   const dependencies = {
     vite: "^4.0.0",

--- a/test/darkmode.test.js
+++ b/test/darkmode.test.js
@@ -31,12 +31,14 @@ describe("darkmode feature", () => {
         scripts: [],
         features: ["darkmode"],
       };
-      const { outDir } = await scaffoldProject(answers);
+      const { outDir, metadata } = await scaffoldProject(answers);
       const file = join(outDir, "darkmode.js");
       assert.ok(existsSync(file));
       const mainFile = readFileSync(join(outDir, "src", "main.ts"), "utf8");
       const matches = mainFile.match(/import '\.\/darkmode\.js';/g) || [];
       assert.equal(matches.length, 1);
+      assert.ok(existsSync(join(outDir, "src", "preload.ts")));
+      assert.ok(metadata.features.includes("preload"));
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;

--- a/test/frameless.test.js
+++ b/test/frameless.test.js
@@ -33,7 +33,7 @@ describe("scaffoldProject", () => {
         scripts: [],
         features: ["frameless"],
       };
-      const { outDir } = await scaffoldProject(answers);
+      const { outDir, metadata } = await scaffoldProject(answers);
       const controlFile = join(
         outDir,
         "src",
@@ -43,6 +43,7 @@ describe("scaffoldProject", () => {
       assert.ok(existsSync(controlFile));
       const preloadFile = join(outDir, "src", "preload.ts");
       assert.ok(existsSync(preloadFile));
+      assert.ok(metadata.features.includes("preload"));
     } finally {
       process.chdir(cwd);
       process.env.PATH = originalPath;


### PR DESCRIPTION
## Summary
- ensure `scaffoldProject` auto-enables preload when darkmode or frameless are selected
- update frameless and darkmode tests to check metadata and preload file

## Testing
- `SKIP_SETUP=1 npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686445147230832fa9c49a1d332eb538