### PR TITLE
Add start script scaffold test

### DIFF
--- a/test/start-script.test.js
+++ b/test/start-script.test.js
@@ -1,0 +1,44 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { scaffoldProject } from "../src/generator.js";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("start script", () => {
+  test("adds start script to package.json", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "scaffold-test-"));
+    const { dir: npmDir } = createNpmStub();
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${originalPath}`;
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const answers = {
+        appName: "start-app",
+        title: "Test",
+        description: "",
+        author: "",
+        license: "MIT",
+        scripts: ["start"],
+        features: [],
+      };
+      const { outDir } = await scaffoldProject(answers);
+      const pkg = JSON.parse(readFileSync(join(outDir, "package.json"), "utf8"));
+      assert.equal(pkg.scripts.start, "node dist/main.js");
+    } finally {
+      process.chdir(cwd);
+      process.env.PATH = originalPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a new test verifying the `start` script is included when selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864455d2ae4832f84446963b3c7a823