### PR TITLE
Add optional SKIP_INSTALL for generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ can tweak this file before running the `dist` script.
 * CLI prompts in `src/wizard.js`
 * Project scaffolding logic in `src/generator.js`
 * Utilities in `src/utils/`
+* Set `SKIP_INSTALL=1` to bypass dependency installation during scaffolding
 
 ## Running Tests
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -46,7 +46,8 @@ async function main() {
 
     const answers = await createAppWizard();
 
-    const result = await scaffoldProject(answers);
+    const skipInstall = process.env.SKIP_INSTALL === "1";
+    const result = await scaffoldProject(answers, { skipInstall });
 
     await showSummaryReport(result);
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -10,7 +10,8 @@ import { execa } from "execa";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export async function scaffoldProject(answers) {
+export async function scaffoldProject(answers, options = {}) {
+  const { skipInstall = false } = options;
   const outDir = path.resolve(process.cwd(), answers.appName);
 
   // helper to remove the project directory on failure
@@ -310,12 +311,16 @@ if (extraImports.length > 0) {
 
   // Install dependencies using chosen package manager
   const pm = answers.packageManager || "npm";
-  try {
-    info("🔧 Installing dependencies...");
-    await execa(pm, ["install"], { cwd: outDir, stdio: "inherit" });
-  } catch (e) {
-    await cleanupProject();
-    throw new Error(`${pm} install failed: ${e.message}. Project directory cleaned up.`);
+  if (!skipInstall) {
+    try {
+      info("🔧 Installing dependencies...");
+      await execa(pm, ["install"], { cwd: outDir, stdio: "inherit" });
+    } catch (e) {
+      await cleanupProject();
+      throw new Error(`${pm} install failed: ${e.message}. Project directory cleaned up.`);
+    }
+  } else {
+    info("⚠️  Skipping dependency installation (SKIP_INSTALL)");
   }
 
   // Initialize Git repo if selected


### PR DESCRIPTION
## Summary
- allow scaffoldProject to skip running npm install
- pass SKIP_INSTALL environment variable from CLI
- document SKIP_INSTALL in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864455cdc84832f946eb3d131654009