### PR TITLE
Implement noninteractive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ create-electron-app --version
 
 Running `create-electron-app` with no arguments starts the interactive wizard.
 
+For automated environments, supply a JSON answers file using `--answers` to skip prompts:
+
+```bash
+create-electron-app my-app --answers ./answers.json
+```
+
+The CLI aborts if no TTY is available and no answers file is provided.
+
 The wizard walks you through:
 
 - Project metadata (name, author, license, description)

--- a/bin/index.js
+++ b/bin/index.js
@@ -35,16 +35,58 @@ if (args.includes("-h") || args.includes("--help")) {
   console.log("Usage: create-electron-app [options]\n" +
     "Run without options to start the interactive wizard.\n" +
     "The wizard lets you choose npm, yarn or pnpm for dependency installation.\n" +
-    "  -h, --help     Show this help\n" +
-    "  -v, --version  Show CLI version");
+    "  -h, --help         Show this help\n" +
+    "  -v, --version      Show CLI version\n" +
+    "  --no-prompt        Fail if prompts would be shown (CI)\n" +
+    "  --answers <file>   JSON answers file for noninteractive use");
   process.exit(0);
+}
+
+// Parse additional options
+let answersPath = null;
+let noPrompt = false;
+const positional = [];
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === "--answers") {
+    answersPath = args[i + 1];
+    i++;
+  } else if (a.startsWith("--answers=")) {
+    answersPath = a.split("=")[1];
+  } else if (a === "--no-prompt") {
+    noPrompt = true;
+  } else if (!a.startsWith("-")) {
+    positional.push(a);
+  }
 }
 
 async function main() {
   try {
     info("🛠️  create-electron-app CLI\n-----------------------------");
 
-    const answers = await createAppWizard();
+    if (!process.stdout.isTTY && !answersPath) {
+      logError("Noninteractive environment detected. Use --answers <file>.");
+      process.exit(1);
+    }
+
+    let answers;
+    if (answersPath) {
+      try {
+        const json = fs.readFileSync(path.resolve(answersPath), "utf8");
+        answers = JSON.parse(json);
+        if (positional[0] && !answers.appName) {
+          answers.appName = positional[0];
+        }
+      } catch (err) {
+        logError(`Failed reading answers file: ${err.message}`);
+        process.exit(1);
+      }
+    } else if (noPrompt) {
+      logError("--no-prompt requires --answers <file>");
+      process.exit(1);
+    } else {
+      answers = await createAppWizard();
+    }
 
     const result = await scaffoldProject(answers);
 

--- a/test/cli-noninteractive.test.js
+++ b/test/cli-noninteractive.test.js
@@ -1,0 +1,51 @@
+import { describe, test } from "node:test";
+import { strict as assert } from "assert";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { execa } from "execa";
+
+function createNpmStub() {
+  const dir = mkdtempSync(join(tmpdir(), "npm-stub-"));
+  const stub = join(dir, "npm");
+  writeFileSync(stub, "#!/bin/sh\nexit 0\n");
+  chmodSync(stub, 0o755);
+  return { dir, stub };
+}
+
+describe("cli noninteractive", () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const cli = join(__dirname, "..", "bin", "index.js");
+
+  test("fails without answers file in CI", async () => {
+    const { exitCode } = await execa("node", [cli], { reject: false });
+    assert.equal(exitCode, 1);
+  });
+
+  test("scaffolds using answers file", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "cli-answers-"));
+    const answers = {
+      appName: "ci-app",
+      title: "Test",
+      description: "",
+      author: "",
+      license: "MIT",
+      scripts: [],
+      features: []
+    };
+    const answersPath = join(tmp, "answers.json");
+    writeFileSync(answersPath, JSON.stringify(answers));
+    const { dir: npmDir } = createNpmStub();
+    const origPath = process.env.PATH;
+    process.env.PATH = `${npmDir}:${origPath}`;
+    try {
+      await execa("node", [cli, "--answers", answersPath], { cwd: tmp });
+      assert.ok(existsSync(join(tmp, answers.appName, "package.json")));
+    } finally {
+      process.env.PATH = origPath;
+      rmSync(tmp, { recursive: true, force: true });
+      rmSync(npmDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add CLI options `--no-prompt` and `--answers` for CI usage
- document new noninteractive mode in README
- test CLI behaviour when run without a TTY

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864443adeb4832f98833018ac024537