### PR TITLE
Fix darkmode build output

### DIFF
--- a/templates/base/tsconfig.json
+++ b/templates/base/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
+    "allowJs": true,
     "outDir": "dist",
     "baseUrl": ".",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- ensure TypeScript copies JavaScript by default

## Testing
- `npm test`
- manual `npm run build` in a scaffolded darkmode app

------
https://chatgpt.com/codex/tasks/task_e_68644513bfd8832fb0d531906188f6e2